### PR TITLE
Add MonthSlider Component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,14 @@
 import './CustomSytles.css';
+import MonthSlider from './components/MonthSlider';
 import NavBar from './components/NavBar';
 
 function App() {
   return (
     <div className="App">
         <NavBar/>
+        <div className='home'>
+                <MonthSlider/>
+        </div>
     </div>
   );
 }

--- a/src/CustomSytles.css
+++ b/src/CustomSytles.css
@@ -1,0 +1,8 @@
+.App{
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+.home{
+        padding: 0px 20px;
+}

--- a/src/components/MonthSlider.jsx
+++ b/src/components/MonthSlider.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import Box from '@mui/material/Box';
+import AppBar from '@mui/material/AppBar';
+import Button from "@mui/material/Button"
+import Typography from '@mui/material/Typography';
+import ArrowCircleRightOutlinedIcon from '@mui/icons-material/ArrowCircleRightOutlined';
+import ArrowCircleLeftOutlinedIcon from '@mui/icons-material/ArrowCircleLeftOutlined';
+const MonthSlider = () => {
+  return (
+        <Box sx={{ flexGrow: 1}}>
+        <AppBar position="static" sx={{p:1,backgroundColor:"#e6c2bf",textAlign:"center",color:"black",display:"flex",flexDirection:"row", justifyContent: 'space-between'}}>
+        <Button variant="text"><ArrowCircleLeftOutlinedIcon sx={{ fontSize: 40 }}/></Button>
+            <Typography variant="h6" sx={{p:1}}><Box component="span" sx={{ fontWeight: "bold"}}>January - 2023</Box></Typography>
+            <Button variant="text"><ArrowCircleRightOutlinedIcon sx={{ fontSize: 40 }}/></Button>
+        </AppBar>
+      </Box>
+  )
+}
+
+export default MonthSlider


### PR DESCRIPTION
Introduce the MonthSlider component, featuring an AppBar with navigation buttons for switching between months. The component includes left and right ArrowCircle buttons for month navigation and displays the current month and year, formatted as "January - 2023." Styling adjustments have been made for a cohesive and visually appealing design. This enhancement contributes to a more interactive and user-friendly interface.